### PR TITLE
Update for fedora 42

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ rpmdev-setuptree
 git clone https://github.com/BrickMan240/tuxedo-drivers-kmod
 
 cd tuxedo-drivers-kmod/
+git checkout update-to-4.14.1
 ./build.sh
 cd ..
 

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ cd ..
 export TD_VERSION=$(cat tuxedo-drivers-kmod/tuxedo-drivers-kmod-common.spec | grep -E '^Version:' | awk '{print $2}')
 
 
-rpm-ostree install ~/rpmbuild/RPMS/x86_64/akmod-tuxedo-drivers-$TD_VERSION-1.fc41.x86_64.rpm ~/rpmbuild/RPMS/x86_64/tuxedo-drivers-kmod-$TD_VERSION-1.fc41.x86_64.rpm ~/rpmbuild/RPMS/x86_64/tuxedo-drivers-kmod-common-$TD_VERSION-1.fc41.x86_64.rpm ~/rpmbuild/RPMS/x86_64/kmod-tuxedo-drivers-$TD_VERSION-1.fc41.x86_64.rpm
+rpm-ostree install ~/rpmbuild/RPMS/x86_64/akmod-tuxedo-drivers-$TD_VERSION-1.fc42.x86_64.rpm ~/rpmbuild/RPMS/x86_64/tuxedo-drivers-kmod-$TD_VERSION-1.fc42.x86_64.rpm ~/rpmbuild/RPMS/x86_64/tuxedo-drivers-kmod-common-$TD_VERSION-1.fc42.x86_64.rpm ~/rpmbuild/RPMS/x86_64/kmod-tuxedo-drivers-$TD_VERSION-1.fc42.x86_64.rpm
 
 KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 

--- a/tuxedo.repo
+++ b/tuxedo.repo
@@ -1,7 +1,7 @@
 [tuxedo]
 name=tuxedo
-baseurl=https://rpm.tuxedocomputers.com/fedora/41/x86_64/base
+baseurl=https://rpm.tuxedocomputers.com/fedora/42/x86_64/base
 enabled=1
 gpgcheck=1
-gpgkey=https://rpm.tuxedocomputers.com/fedora/41/0x54840598.pub.asc
+gpgkey=https://rpm.tuxedocomputers.com/fedora/42/0x54840598.pub.asc
 skip_if_unavailable=False


### PR DESCRIPTION
The image build failed as the ublue images were updated to Fedora 42, but the build.sh still tries to build for F41.

I updated the build.sh and tuxedo.repo, then the images build without issues.